### PR TITLE
refactor: only define string.replaceAll if it is missing

### DIFF
--- a/src/prototype-functions.js
+++ b/src/prototype-functions.js
@@ -1,3 +1,5 @@
-String.prototype.replaceAll = function (search, replacement) {
-    return this.split(search).join(replacement);
-};
+if (String.prototype.replaceAll == null) {
+    String.prototype.replaceAll = function (search, replacement) {
+        return this.split(search).join(replacement);
+    };
+}


### PR DESCRIPTION
In newer versions of JS String.replaceAll is natively present and supports more features than just simple string replacements.
Replacing the implementation with something like the current variant breaks other code.

- https://github.com/faker-js/faker/blob/48931a56b761352a35d2f7f6c1240231a5df5efd/src/modules/location/index.ts#L110-L115
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll

This PR changes the poly-filling to omit the function if it is already defined.

Minimal reproduction:

````ts
import { faker } from '@faker-js/faker';
import swaggerAutogen from 'swagger-autogen';

swaggerAutogen();
console.log(faker.location.streetAddress());
````

Expected:

````txt
1234 Madison Street
````

Actual:

````txt
e=>this.faker.string.numeric({length:e.length,allowLeadingZeros:!1}) Madison Street
````